### PR TITLE
fix(vercel): add frontend build step and SPA fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,3 @@ Servidor ejecutándose en http://localhost:10000
 ```
 
 ---
-
-If you want, I can add commands for migrations, tests, or a Windows-specific `dev` script—tell me which one to include.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "main": "MariaE_API/routes/server.js",
   "author": "haqui82",
   "license": "ISC",
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
     "start": "node MariaE_API/routes/server.js",
     "dev": "nodemon MariaE_API/routes/server.js",
     "test": "echo \"No tests\" && exit 0",
-    "build": "echo 'No build step required'"
+    "build": "node scripts/build.js"
   },
   "static": {
     "public": "Front-End/html"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,29 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+async function copyDir(src, dest) {
+  await fs.rm(dest, { recursive: true, force: true });
+  await fs.mkdir(dest, { recursive: true });
+  const entries = await fs.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await fs.copyFile(srcPath, destPath);
+    }
+  }
+}
+
+(async () => {
+  const src = path.join(__dirname, '..', 'Front-End', 'html');
+  const dest = path.join(__dirname, '..', 'dist');
+  try {
+    await copyDir(src, dest);
+    console.log('Build completed: dist/ created');
+  } catch (err) {
+    console.error('Build failed:', err);
+    process.exit(1);
+  }
+})();

--- a/vercel.json
+++ b/vercel.json
@@ -6,13 +6,13 @@
       "use": "@vercel/node"
     },
     {
-      "src": "Front-End/html/**",
-      "use": "@vercel/static"
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
     }
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "MariaE_API/routes/server.js" },
-    { "src": "/", "dest": "Front-End/html/index.html" },
-    { "src": "/(.*)", "dest": "Front-End/html/index.html" }
+    { "src": "/(.*)", "dest": "/index.html" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -6,9 +6,8 @@
       "use": "@vercel/node"
     },
     {
-      "src": "Front-End/html/index.html",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "Front-End/html" }
+      "src": "Front-End/html/**",
+      "use": "@vercel/static"
     }
   ],
   "routes": [


### PR DESCRIPTION
Commit body (detailed):

Add build.js to copy html → dist
Set package.json "build" to node scripts/build.js and add "engines": { "node": "18.x" }
Update vercel.json to use @vercel/static-build with "distDir": "dist" and add SPA rewrite to "/index.html"
Keep API route mapping for /api/*

Commands to run 🔧
git add package.json vercel.json scripts/build.js
git commit -m "fix(vercel): add frontend build step and SPA fallback" \
  -m "Add build script to generate dist/ from Front-End/html; set Node engine to 18.x; configure vercel.json to use @vercel/static-build with distDir 'dist' and SPA rewrite to /index.html; preserve API route."
# Push to your branch (replace remote/name if needed)
git push origin log/log-current-user-none
# Or if you use the 'mvp' remote:
git push mvp log/log-current-user-none

PR suggestion 📝
Title: fix(vercel): add frontend build and SPA fallback
Description: Adds a build step that outputs static files to dist/, updates package.json to run it on npm run build, and configures Vercel to deploy the static build and serve index.html for client-side routes.